### PR TITLE
Right-click to delete

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import tkinter as tk
+from tkinter import messagebox
 from Init_Graph import *
 import os 
 
@@ -34,6 +35,7 @@ class MatrixGUI:
         self.draw_matrix()
 
         self.canvas.bind("<Button-1>", self.update_square_color)
+        self.canvas.bind("<Button-3>", self.delete_square)
 
         get_matrix_button = tk.Button(self.root, text="Get Matrix", command=self.get_matrix, bg="#4caf50", fg="white", font=("Helvetica", 12), padx=10, pady=5)
         get_matrix_button.grid(row=self.rows + 1, column=self.cols + 1, padx=10, pady=10)
@@ -63,6 +65,15 @@ class MatrixGUI:
             current_color = self.matrix[row_index][col_index]
             new_color = (current_color + 1) % len(["white", "black", "red", "green"])
             self.matrix[row_index][col_index] = new_color
+            self.draw_matrix()
+    
+    def delete_square(self, event):
+        x, y = event.x, event.y
+        col_index = x // 30
+        row_index = y // 30
+
+        if 0 <= row_index < self.rows and 0 <= col_index < self.cols:
+            self.matrix[row_index][col_index] = 0
             self.draw_matrix()
 
     def draw_matrix(self):
@@ -112,5 +123,3 @@ if __name__ == "__main__":
         root = tk.Tk()
         app = MatrixGUI(root)
         root.mainloop()
-
-        

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,4 @@
 import tkinter as tk
-from tkinter import messagebox
 from Init_Graph import *
 import os 
 


### PR DESCRIPTION
This simple pull request simplifies the process of resetting single squares, by allowing users to right-click them. A function `delete_square()` has been bound to the `Mouse-3` event (right mouse button).

This function resets the color of the selected square to white, so users won't have to left-click several times in order to remove something from a cell on the board.

Please let me know if you have any questions or would like to change something!